### PR TITLE
only provide autocompletion for property name

### DIFF
--- a/src/ansibleCompletionItemProvider.ts
+++ b/src/ansibleCompletionItemProvider.ts
@@ -22,6 +22,11 @@ export class AnsibleCompletionItemProvider implements vscode.CompletionItemProvi
         let prefix = range ? document.getText(range) : '';
         let lineText = document.lineAt(position.line).text;
 
+        var index = lineText.indexOf(':');
+        if (index != -1 && index < range.end.character) {
+            return;
+        }
+
         if (pattern_variable.exec(lineText)) {
             return this.completionEngine.getVariablesCompletionItem(document, prefix, lineText);
         } else {


### PR DESCRIPTION
## Summary
<!--Describe the change berifly-->
Fix Issue #105 . only provide autocompletion to property names, not values.
## Issue Type
<!--Pick one below and delete the rest-->
- New Feature