### PR TITLE
[Discussion] [Live Share] Restricting language services to local files

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,6 +16,11 @@ import { LocalAnsibleRunner } from './localAnsibleRunner';
 import { SSHRunner } from './sshRunner';
 import { DeploymentTemplate } from './deploymentTemplate';
 
+const documentSelector = [
+    { language: 'yaml', scheme: 'file' },
+    { language: 'yaml', scheme: 'untitled' }
+];
+
 export function activate(context: vscode.ExtensionContext) {
     console.log('Congratulations, your extension "vscode-ansible" is now active!');
     var outputChannel = vscode.window.createOutputChannel("VSCode extension for Ansible");
@@ -25,7 +30,7 @@ export function activate(context: vscode.ExtensionContext) {
     utilities.generateCredentialsFile();
 
     const triggerCharacters = ' abcdefghijklmnopqrstuvwxyz'.split('');
-    context.subscriptions.push(vscode.languages.registerCompletionItemProvider(['yaml'], new AnsibleCompletionItemProvider(), ...triggerCharacters));
+    context.subscriptions.push(vscode.languages.registerCompletionItemProvider(documentSelector, new AnsibleCompletionItemProvider(), ...triggerCharacters));
 
 
     var dockerRunner = new DockerRunner(outputChannel);
@@ -65,7 +70,7 @@ export function activate(context: vscode.ExtensionContext) {
     }
 
     var clientOptions: LanguageClientOptions = {
-        documentSelector: ['yaml'],
+        documentSelector,
         synchronize: {
             configurationSection: 'ansible',
             fileEvents: vscode.workspace.createFileSystemWatcher('**/*.?(e)y?(a)ml')


### PR DESCRIPTION
In preparation for [Visual Studio Live Share](https://aka.ms/vsls) adding support for "guests" to receive remote language services for Ansible, this PR simply updates the current `DocumentSelector` to be limited to `file` and `untitled` (unsaved) files. This way, when someone has the Ansible extension installed, and joins a Live Share session (where files use the `vsls:` scheme), their language services will be entirely derived from the remote/host side, which provides a more accurate and project-wide experience (guests in Live Share don't have local file access to the project they're collaborating with).

*Note: As an example, the TypeScript/JavaScript language services that come in-box with VS Code [already have this scheme restriction](https://github.com/Microsoft/vscode/blob/master/extensions/typescript-language-features/src/utils/fileSchemes.ts#L12), and so this PR replicates that behavior.*