### PR TITLE
add config for copy workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
       {
         "command": "vscode-ansible.sync-folder-ssh",
         "title": "Copy folder to Remote Host",
-        "category": "Ansible"        
+        "category": "Ansible"
       }
     ],
     "menus": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
       {
         "command": "vscode-ansible.sync-folder-ssh",
         "title": "Copy folder to Remote Host",
-        "category": "Ansible"
+        "category": "Ansible"        
       }
     ],
     "menus": {
@@ -151,6 +151,11 @@
           "type": "boolean",
           "default": true,
           "description": "Enable/Disable ansible autocompletion"
+        },
+        "ansible.copyWorkspace": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable/Disable copying whole workspace to remote SSH host"
         }
       }
     }

--- a/src/sshRunner.ts
+++ b/src/sshRunner.ts
@@ -61,13 +61,10 @@ export class SSHRunner extends TerminalBaseRunner {
         let targetPlaybook = target;
 
 
-        // ask for weather to sync workspace
-        const cancelItem: vscode.MessageItem = { title: "Cancel" };
-        const okItem: vscode.MessageItem = { title: "Ok" };
-        let response = await vscode.window.showWarningMessage('Copy Workspace to Remote host?', okItem, cancelItem);
+        // check configuration weather to sync workspace
+        let copyWorkspace = utilities.getCodeConfiguration<boolean>('ansible', 'copyWorkspace');
 
-        if (response && response === okItem) {
-
+        if (copyWorkspace) {
             src = utilities.getWorkspaceRoot(playbook) + '/';
             target = path.join('\./', path.basename(src)) + '/';
             targetPlaybook = ['\./' + path.basename(src), path.relative(src, playbook)].join(path.posix.sep).replace(/\\/g, '/');
@@ -77,10 +74,7 @@ export class SSHRunner extends TerminalBaseRunner {
             } catch (err) {
                 return;
             }
-        }
-
-        if (!response || response === cancelItem) {
-
+        } else {
             this._outputChannel.append('\nCopying ' + src + ' to ' + targetServer.host + '..');
             this._outputChannel.show();
 


### PR DESCRIPTION
## Summary
<!--Describe the change berifly-->
add configuration to copy workspace, instead of a warning box to interrupt user's work flow.

## Issue Type
<!--Pick one below and delete the rest-->
- Bug fixing

Issue #120 