### PR TITLE
VSCode Ansible and remote - SSH compatibility for docker

### DIFF
--- a/package.json
+++ b/package.json
@@ -239,6 +239,11 @@
           "type": "string",
           "default": "",
           "description": "Location of Azure REST specification."
+        },
+        "ansible.targetName": {
+          "type": "string",
+          "default": "",
+          "descritption": "Specify which folder will be used on the target."
         }
       }
     }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,12 +3,14 @@ export class Constants {
     public static LineSeperator = Array(50).join('=');
     public static AzureAccountExtensionId = 'ms-vscode.azure-account';
     public static DockerImageName = 'microsoft/ansible:latest';
+    public static TargetName = '${workspaceFolderBasename}';
     public static AnsibleTerminalName = 'Ansible';
     public static UserAgentName = 'VSCODEEXT_USER_AGENT';
     public static Config_cloudShellConfirmed = 'cloudShellConfirmed';
     public static Config_credentialConfigured = 'credentialsConfigured';
     public static Config_credentialsFile = 'credentialsFile';
     public static Config_dockerImage = 'dockerImage';
+    public static Config_targetName = 'targetName';
     public static Config_useWSL = 'useWSL';
     public static Config_terminalInitCommand = 'terminalInitCommand';
     public static Config_fileCopyConfig = 'fileCopyConfig';


### PR DESCRIPTION
## Summary
Add a variable "ansible.targetName" to specify the repository name to use on the docker's container.
This is useful when Ansible plugin is used with Remote - SSH because the folder name contain an unwanted character '['.

## Issue Type
- New Feature
