### PR TITLE
Issue #269 - Ansible modules docs links broken

### DIFF
--- a/server/src/services/yamlHover.ts
+++ b/server/src/services/yamlHover.ts
@@ -70,7 +70,7 @@ export class YAMLHover {
 
     private createHover(content: string, range: Range): Hover {
         let result: Hover = {
-            contents: `module, documentation at http://docs.ansible.com/ansible/${content}_module.html`,
+            contents: `module, documentation at http://docs.ansible.com/ansible/modules/${content}_module.html`,
             range: range
         }
         return result;

--- a/src/completionData.ts
+++ b/src/completionData.ts
@@ -21,7 +21,7 @@ export function parseAnsibleCompletionFile(sourcefile: string): Promise<AnsibleC
         modules = data.modules.map((module) => {
             let item = new AnsibleCompletionItem(module.module, CompletionItemKind.Function);
             item.detail = 'module: \n' + `${module.short_description || ''}`;
-            item.documentation = `http://docs.ansible.com/ansible/${module.module}_module.html`;
+            item.documentation = `http://docs.ansible.com/ansible/modules/${module.module}_module.html`;
 
             if (module.deprecated) {
                 item.detail = `(Deprecated) ${item.detail}`;


### PR DESCRIPTION
## Summary
Issue #269 
This change fixes the broken links for the Ansible modules DOCs

## Issue Type
<!--Pick one below and delete the rest-->
- New Feature
- Bug fixing